### PR TITLE
Move PyPI release testing into own workflow

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -1,0 +1,48 @@
+name: PyPI release testing of baked projects
+
+on:
+  # This test takes a very long time to complete, but will only be affected by very
+  # specific changes or upstream changes. We therefore restrict this test to manual
+  # triggers and cron jobs.
+  workflow_dispatch:
+  schedule:
+  - cron: "0 5 * * 1"
+
+jobs:
+  test-pypi-release:
+    name: Testing PyPI release
+    runs-on: ubuntu-18.04
+
+    steps:
+    - name: Checking out the cookie cutter repository
+      uses: actions/checkout@v2
+
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.8
+
+    - name: Install test requirements
+      run: |
+        python -m pip install -r requirements-dev.txt
+
+    - name: Set up git identity
+      run: |
+        git config --global user.email "ssc@citestuser.com"
+        git config --global user.name "SSC CI Test User"
+
+    - name: Set up SSH Agent to deploy to test repositories
+      uses: webfactory/ssh-agent@v0.4.1
+      with:
+        ssh-private-key: |
+          ${{ secrets.GHA_TEST_PRIVATE_KEY }}
+
+    - name: Test deploying the baked project to Github + Gitlab.com
+      run: |
+        python -m pytest -m deploy
+
+    - name: Run tests for upstream integrations
+      env:
+        GH_API_ACCESS_TOKEN: ${{ secrets.GH_API_ACCESS_TOKEN }}
+      run: |
+        python -m pytest -m pypi

--- a/pytest.ini
+++ b/pytest.ini
@@ -4,3 +4,4 @@ markers =
     deploy: marks tests that require a deploy key setup to be run
     integrations: marks tests that require previous run of deploy tests and might need API keys set up
     local: marks tests that only perform local operations
+    pypi: marks expensive tests that build wheels in CI

--- a/tests/test_deploy_bake.py
+++ b/tests/test_deploy_bake.py
@@ -1,13 +1,11 @@
 import github
 import gitlab
 import os
-import re
 import pytest
 import requests
 import subprocess
 import time
 from contextlib import contextmanager
-from packaging import version
 
 
 @contextmanager
@@ -113,60 +111,3 @@ def test_readthedocs_deploy():
 
     assert build['success']
     assert build["commit"] == sha
-
-
-@pytest.mark.integrations
-def test_pypi_deploy():
-    # Find out the current version of the PyPI package
-    def upstream_version(url):
-        response = requests.get(url)
-        if response.status_code == 200:
-            return version.parse(response.json()['info']['version'])
-        else:
-            return version.parse('0.0.0')
-
-    # Construct a version, by finding the maximum version across Github, PyPI and TestPyPI and increasing that
-    gh = github.Github(os.getenv("GH_API_ACCESS_TOKEN"))
-    repo = gh.get_repo('dokempf/test-github-actions-cookiecutter-cpp-project')
-    current_version = max([
-        upstream_version('https://pypi.org/pypi/testgithubactionscookiecuttercppproject/json'),
-        upstream_version('https://test.pypi.org/pypi/testgithubactionscookiecuttercppproject/json'),
-        version.parse(repo.get_latest_release().title[1:])
-    ])
-    next_version = version.Version('{}.{}.{}'.format(current_version.major, current_version.minor, current_version.micro + 1))
-
-    # Modify the version in setup.py and commit the change
-    subprocess.check_call("git clone git@github.com:dokempf/test-github-actions-cookiecutter-cpp-project.git".split())
-    os.chdir("test-github-actions-cookiecutter-cpp-project")
-    with open("setup.py", "r") as source:
-        lines = source.readlines()
-    with open("setup.py", "w") as source:
-        for line in lines:
-            source.write(re.sub(r'version=.*$', 'version="{}",'.format(str(next_version)), line))
-    subprocess.check_call("git add setup.py".split())
-    subprocess.check_call(["git", "commit", "-m", "Bump version in setup.py"])
-    subprocess.check_call("git push -f origin main:pypi_release".split())
-    time.sleep(2)
-
-    # Create the release - this will trigger the PyPI release workflow
-    repo.create_git_release(
-        'v{}'.format(str(next_version)),
-        'v{}'.format(str(next_version)),
-        "Test Release",
-        target_commitish='pypi_release'
-    )
-    time.sleep(2)
-
-    # Identify the PyPI release workflow
-    branch = repo.get_branch('pypi_release')
-    workflow = repo.get_workflow("pypi.yml").get_runs()[0]
-    assert workflow.head_sha == branch.commit.sha
-
-    # Poll the workflow status
-    while workflow.status != 'completed':
-        # We poll at a relatively large interval to avoid running against the Github API
-        # limitations in times of heavy development activities on the cookiecutter.
-        time.sleep(30)
-        workflow = repo.get_workflow("pypi.yml").get_runs()[0]
-
-    assert workflow.conclusion == 'success'

--- a/tests/test_pypi_release.py
+++ b/tests/test_pypi_release.py
@@ -1,0 +1,65 @@
+import github
+import os
+import re
+import pytest
+import requests
+import subprocess
+import time
+from packaging import version
+
+
+@pytest.mark.pypi
+def test_pypi_deploy():
+    # Find out the current version of the PyPI package
+    def upstream_version(url):
+        response = requests.get(url)
+        if response.status_code == 200:
+            return version.parse(response.json()['info']['version'])
+        else:
+            return version.parse('0.0.0')
+
+    # Construct a version, by finding the maximum version across Github, PyPI and TestPyPI and increasing that
+    gh = github.Github(os.getenv("GH_API_ACCESS_TOKEN"))
+    repo = gh.get_repo('dokempf/test-github-actions-cookiecutter-cpp-project')
+    current_version = max([
+        upstream_version('https://pypi.org/pypi/testgithubactionscookiecuttercppproject/json'),
+        upstream_version('https://test.pypi.org/pypi/testgithubactionscookiecuttercppproject/json'),
+        version.parse(repo.get_latest_release().title[1:])
+    ])
+    next_version = version.Version('{}.{}.{}'.format(current_version.major, current_version.minor, current_version.micro + 1))
+
+    # Modify the version in setup.py and commit the change
+    subprocess.check_call("git clone git@github.com:dokempf/test-github-actions-cookiecutter-cpp-project.git".split())
+    os.chdir("test-github-actions-cookiecutter-cpp-project")
+    with open("setup.py", "r") as source:
+        lines = source.readlines()
+    with open("setup.py", "w") as source:
+        for line in lines:
+            source.write(re.sub(r'version=.*$', 'version="{}",'.format(str(next_version)), line))
+    subprocess.check_call("git add setup.py".split())
+    subprocess.check_call(["git", "commit", "-m", "Bump version in setup.py"])
+    subprocess.check_call("git push -f origin main:pypi_release".split())
+    time.sleep(2)
+
+    # Create the release - this will trigger the PyPI release workflow
+    repo.create_git_release(
+        'v{}'.format(str(next_version)),
+        'v{}'.format(str(next_version)),
+        "Test Release",
+        target_commitish='pypi_release'
+    )
+    time.sleep(2)
+
+    # Identify the PyPI release workflow
+    branch = repo.get_branch('pypi_release')
+    workflow = repo.get_workflow("pypi.yml").get_runs()[0]
+    assert workflow.head_sha == branch.commit.sha
+
+    # Poll the workflow status
+    while workflow.status != 'completed':
+        # We poll at a relatively large interval to avoid running against the Github API
+        # limitations in times of heavy development activities on the cookiecutter.
+        time.sleep(30)
+        workflow = repo.get_workflow("pypi.yml").get_runs()[0]
+
+    assert workflow.conclusion == 'success'


### PR DESCRIPTION
It takes 15-20 minutes that cannot really be reduced but only touches upon a small portion of code.