### PR TITLE
Make use submodule optional

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,26 @@ jobs:
       run: |
         choco install -y doxygen.install
 
+    - name: Install Catch2 (Linux + MacOS)
+      if: runner.os != 'Windows'
+      run: |
+        git clone -b v2.13.3 https://github.com/catchorg/Catch2.git
+        cd Catch2
+        mkdir build
+        cd build
+        cmake -DBUILD_TESTING=OFF  ..
+        sudo cmake --build . --target install
+
+    - name: Install Catch2 (Windows)
+      if: runner.os == 'Windows'
+      run: |
+        git clone -b v2.13.3 https://github.com/catchorg/Catch2.git
+        cd Catch2
+        mkdir build
+        cd build
+        cmake -DBUILD_TESTING=OFF  ..
+        cmake --build . --target install
+
     - name: Set up git identity
       run: |
         git config --global user.email "ssc@citestuser.com"

--- a/README.md
+++ b/README.md
@@ -55,6 +55,9 @@ This cookiecutter accepts the following configuration options:
   from the specified remote URL and the given project name.
 * `full_name`: Author name, defaults to `Your Name`
 * `license` adds a license file to the repository. It can be chosen from [MIT](https://opensource.org/licenses/MIT) (default), [BSD-2](https://opensource.org/licenses/BSD-2-Clause), [GPL-3.0](https://opensource.org/licenses/GPL-3.0), [LGPL-3.0](https://opensource.org/licenses/LGPL-3.0) or it can be omitted.
+* `use_submodules`: Whether `git submodule` should be used to add version-pinned external
+  dependencies (like e.g. the testing framework `Catch2`). If you do not know what git submodules
+  are, you should select `No`.
 * `github_actions_ci`: Whether to add a CI workflow for Github Actions
 * `gitlab_ci`: Whether to add a CI workflow for GitLab CI
 * `readthedocs`: Whether to create a Sphinx-documentation that can automatically be deployed to readthedocs.org

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -4,6 +4,7 @@
     "project_slug": "{%- if cookiecutter.remote_url == 'None' -%}{{ cookiecutter.project_name|replace('+', 'p')|slugify }}{% else %}{{ cookiecutter.remote_url.split('/')[-1]|replace('.git', '')}}{%- endif -%}",
     "full_name": "Your Name",
     "license": ["MIT", "BSD-2", "GPL-3.0", "LGPL-3.0", "None"],
+    "use_submodules": ["Yes", "No"],
     "github_actions_ci": ["Yes", "No"],
     "gitlab_ci": ["No", "Yes"],
     "readthedocs": ["Yes", "No"],

--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -47,6 +47,7 @@ def conditional_remove(condition, path):
 
 
 conditional_remove(True, "ext/.keep")
+conditional_remove("{{ cookiecutter.use_submodules }}" == "No", "ext")
 conditional_remove("{{ cookiecutter.license }}" == "None", "LICENSE.md")
 conditional_remove("{{ cookiecutter.gitlab_ci }}" == "No", ".gitlab-ci.yml")
 conditional_remove("{{ cookiecutter.readthedocs }}" == "No", ".readthedocs.yml")
@@ -63,9 +64,13 @@ conditional_remove(os.stat("TODO.md").st_size == 0, "TODO.md")
 
 # Set up a Git repository with submodules
 with GitRepository() as repo:
+{% if cookiecutter.use_submodules == "Yes" %}
     repo.add_submodule("https://github.com/catchorg/Catch2.git", "ext/Catch2", tag="v2.13.3")
     if "{{ cookiecutter.python_bindings }}" == "Yes":
         repo.add_submodule("https://github.com/pybind/pybind11.git", "ext/pybind11", tag="v2.6.1")
+{% else %}
+    pass
+{% endif %}
 
 
 # Print a message about success

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,6 +2,7 @@ breathe==4.24.1
 cookiecutter==1.7.2
 jsonschema==3.2.0
 packaging==20.4
+pybind11==2.6.1
 PyGithub==1.54
 pytest==5.4.3
 pytest-cookies==0.5.1

--- a/tests/test_bake_project.py
+++ b/tests/test_bake_project.py
@@ -43,8 +43,14 @@ def check_bake(bake):
 
 
 @pytest.mark.local
-def test_project_tree(cookies):
-    bake = cookies.bake(extra_context={'project_slug': 'test_project'})
+@pytest.mark.parametrize("submodules", ("Yes", "No"))
+def test_ctest_run(cookies, submodules):
+    bake = cookies.bake(
+        extra_context={
+            'project_slug': 'test_project',
+            'use_submodules': submodules,
+        }
+    )
     check_bake(bake)
     with inside_bake(bake):
         os.makedirs("build")
@@ -105,8 +111,15 @@ def test_gitlabci(cookies):
 
 
 @pytest.mark.local
-def test_python(cookies, virtualenv):
-    bake = cookies.bake(extra_context={'project_slug': 'my-project', 'python_bindings': 'Yes'})
+@pytest.mark.parametrize("submodules", ("Yes", "No"))
+def test_python(cookies, virtualenv, submodules):
+    bake = cookies.bake(
+        extra_context={
+            'project_slug': 'my-project',
+            'python_bindings': 'Yes',
+            'submodules': submodules,
+        }
+    )
     check_bake(bake)
     with inside_bake(bake):
         # Make sure that our Python package can be installed and imported

--- a/tests/test_deploy_bake.py
+++ b/tests/test_deploy_bake.py
@@ -33,6 +33,7 @@ def test_push_remote(cookies):
             'readthedocs': 'Yes',
             'python_bindings': 'Yes',
             'pypi_release': 'Yes',
+            'use_submodules': 'No',
         }
     )
     with inside_bake(bake):
@@ -83,7 +84,7 @@ def test_gitlab_ci_on_deployed_bake():
         time.sleep(5)
         pipeline.refresh()
         if pipeline.status in ["failed", "canceled", "skipped"]:
-            pytest.fail("The Gitlab API reported Status '{}' while we were waiting for 'success'".format(status))
+            pytest.fail("The Gitlab API reported Status '{}' while we were waiting for 'success'".format(pipeline.status))
 
 
 @pytest.mark.integrations

--- a/{{cookiecutter.project_slug}}/.github/workflows/ci.yml
+++ b/{{cookiecutter.project_slug}}/.github/workflows/ci.yml
@@ -22,8 +22,53 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+{% if cookiecutter.use_submodules == "Yes" %}
       with:
         submodules: 'recursive'
+{%- endif %}
+
+{% if cookiecutter.use_submodules == "No" %}
+    - name: Install Catch2 (Linux + MacOS)
+      if: runner.os != 'Windows'
+      run: |
+        git clone -b v2.13.3 https://github.com/catchorg/Catch2.git
+        cd Catch2
+        mkdir build
+        cd build
+        cmake -DBUILD_TESTING=OFF  ..
+        sudo cmake --build . --target install
+
+    - name: Install Catch2 (Windows)
+      if: runner.os == 'Windows'
+      run: |
+        git clone -b v2.13.3 https://github.com/catchorg/Catch2.git
+        cd Catch2
+        mkdir build
+        cd build
+        cmake -DBUILD_TESTING=OFF  ..
+        cmake --build . --target install
+{% if cookiecutter.python_bindings == "Yes" %}
+    - name: Install Pybind11 (Linux + MacOS)
+      if: runner.os != 'Windows'
+      run: |
+        git clone -b v2.6.1 https://github.com/pybind/pybind11.git
+        cd pybind11
+        mkdir build
+        cd build
+        cmake -DBUILD_TESTING=OFF  ..
+        sudo cmake --build . --target install
+
+    - name: Install Pybind11 (Windows)
+      if: runner.os == 'Windows'
+      run: |
+        git clone -b v2.6.1 https://github.com/pybind/pybind11.git
+        cd pybind11
+        mkdir build
+        cd build
+        cmake -DBUILD_TESTING=OFF  ..
+        cmake --build . --target install
+{%- endif %}
+{%- endif %}
 
     - name: make build directory
       run: cmake -E make_directory ${{ "{{runner.workspace}}" }}/build

--- a/{{cookiecutter.project_slug}}/.gitlab-ci.yml
+++ b/{{cookiecutter.project_slug}}/.gitlab-ci.yml
@@ -1,8 +1,28 @@
+{% if cookiecutter.use_submodules == "Yes" -%}
 variables:
   GIT_SUBMODULE_STRATEGY: recursive
+{%- endif %}
 
 .template: &template
   script:
+{% if cookiecutter.python_bindings == "Yes" and cookiecutter.use_submodules == "No" %}
+    - git clone -b v2.6.1 https://github.com/pybind/pybind11.git
+    - cd pybind11
+    - mkdir build
+    - cd build
+    - cmake -DBUILD_TESTING=OFF ..
+    - sudo make install
+    - cd ..
+{%- endif %}
+{% if cookiecutter.use_submodules == "No" %}
+    - git clone -b v2.13.3 https://github.com/catchorg/Catch2.git
+    - cd Catch2
+    - mkdir build
+    - cd build
+    - cmake -DBUILD_TESTING=OFF ..
+    - sudo make install
+    - cd ..
+{%- endif %}
     - cmake -E make_directory build
     - cd build
     - cmake -DCMAKE_BUILD_TYPE=Debug ..

--- a/{{cookiecutter.project_slug}}/CMakeLists.txt
+++ b/{{cookiecutter.project_slug}}/CMakeLists.txt
@@ -7,8 +7,6 @@ project({{ cookiecutter.project_slug }} VERSION 0.0.1 LANGUAGES CXX)
 set(CMAKE_CXX_STANDARD {{ cookiecutter.cxx_minimum_standard }})
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-# this needs to be in the top level CMakeLists.txt:
-include(CTest)
 {% if cookiecutter.python_bindings == "Yes" -%}
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 {%- endif %}
@@ -19,7 +17,15 @@ add_subdirectory(src)
 add_subdirectory(app)
 
 # compile the tests
+{% if cookiecutter.use_submodules == "Yes" -%}
 add_subdirectory(ext/Catch2)
+include(./ext/Catch2/contrib/Catch.cmake)
+{% else %}
+find_package(Catch2 REQUIRED)
+include(Catch)
+{%- endif %}
+# this needs to be in the top level CMakeLists.txt:
+include(CTest)
 add_subdirectory(tests)
 
 {% if cookiecutter.doxygen == "Yes" -%}
@@ -28,6 +34,14 @@ add_subdirectory(doc)
 {%- endif %}
 {% if cookiecutter.python_bindings == "Yes" -%}
 # Add Python bindings
+{% if cookiecutter.use_submodules == "Yes" -%}
 add_subdirectory(ext/pybind11)
+{% else %}
+find_package(pybind11)
+{%- endif %}
 add_subdirectory(python)
 {%- endif %}
+
+# This prints a summary of found dependencies
+include(FeatureSummary)
+feature_summary(WHAT ALL)

--- a/{{cookiecutter.project_slug}}/README.md
+++ b/{{cookiecutter.project_slug}}/README.md
@@ -45,7 +45,9 @@ Building {{ cookiecutter.project_name }} requires the following software install
 * A C++{{ cookiecutter.cxx_minimum_standard }}-compliant compiler
 * CMake `>= 3.9`
 {% if cookiecutter.doxygen == "Yes" or cookiecutter.readthedocs == "Yes" -%}* Doxygen (optional, documentation building is skipped if missing){% endif %}
+{% if cookiecutter.use_submodules == "No" -%}* The testing framework [Catch2](https://github.com/catchorg/Catch2) for building the test suite{%- endif %}
 {% if cookiecutter.python_bindings == "Yes" -%}* Python `>= 3.6` for building Python bindings{% endif %}
+{% if cookiecutter.use_submodules == "No" and cookiecutter.python_bindings == "Yes" -%}* The [PyBind11](https://github.com/pybind/pybind11) library for building Python bindings{%- endif %}
 
 # Building {{ cookiecutter.project_name }}
 

--- a/{{cookiecutter.project_slug}}/TODO.md
+++ b/{{cookiecutter.project_slug}}/TODO.md
@@ -8,6 +8,12 @@ The following tasks need to be done to get a fully working project:
 {%- else -%}
 * Push to your remote repository for the first time by doing `git push origin main`.
 {%- endif %}
+* Make sure that the following software is installed on your computer:
+  * A C++-{{ cookiecutter.cxx_minimum_standard}}-compliant C++ compiler
+  * CMake `>= 3.9`
+{% if cookiecutter.use_submodules == "No" %}  * The testing framework [Catch2](https://github.com/catchorg/Catch2)
+{% if cookiecutter.python_bindings == "Yes" -%}  * The [PyBind11](https://github.com/pybind/pybind11) library{% endif %}
+{%- endif %}
 {% if cookiecutter.gitlab_ci == "Yes" -%}
 * Make sure that CI/CD pipelines are enabled in your Gitlab project settings and that
   there is a suitable Runner available. If you are using the cloud-hosted gitlab.com,

--- a/{{cookiecutter.project_slug}}/tests/CMakeLists.txt
+++ b/{{cookiecutter.project_slug}}/tests/CMakeLists.txt
@@ -2,5 +2,4 @@ add_executable(tests tests.cpp {{ cookiecutter.project_slug }}_t.cpp)
 target_link_libraries(tests PUBLIC {{ cookiecutter.project_slug }} Catch2::Catch2)
 
 # allow user to run tests with `make test` or `ctest`
-include(../ext/Catch2/contrib/Catch.cmake)
 catch_discover_tests(tests)


### PR DESCRIPTION
This introduces a configuration switch `use_submodules` that
controls whether external dependencies are added as submodules
or whether they are searched for by CMake.

Additionally, the deploy tests are switched to using no submodules.
The idea behind that is that the setup with submodules is covered
quite well in the local tests, where as the no-submodule case requires
adaptation of the CI workflow.

This currently affects Catch2 and pybind11.

This fixes #20 