### PR TITLE
Add timeout for deploy test

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,6 +5,7 @@ packaging==20.4
 PyGithub==1.54
 pytest==5.4.3
 pytest-cookies==0.5.1
+pytest-timeout==1.4.2
 pytest-virtualenv==1.7.0
 python-gitlab==2.5.0
 requests==2.24.0

--- a/tests/test_deploy_bake.py
+++ b/tests/test_deploy_bake.py
@@ -44,6 +44,7 @@ def test_push_remote(cookies):
 
 
 @pytest.mark.integrations
+@pytest.mark.timeout(300)
 def test_github_actions_ci_on_deployed_bake():
     # Authenticate with the Github API
     gh = github.Github(os.getenv("GH_API_ACCESS_TOKEN"))
@@ -65,6 +66,7 @@ def test_github_actions_ci_on_deployed_bake():
 
 
 @pytest.mark.integrations
+@pytest.mark.timeout(300)
 def test_gitlab_ci_on_deployed_bake():
     # Authenticate with Gitlab API
     gl = gitlab.Gitlab('https://gitlab.com', private_token=os.getenv("GL_API_ACCESS_TOKEN"))
@@ -85,6 +87,7 @@ def test_gitlab_ci_on_deployed_bake():
 
 
 @pytest.mark.integrations
+@pytest.mark.timeout(300)
 def test_readthedocs_deploy():
     # Authenticate with the Github API to get the upstream commit
     gh = github.Github(os.getenv("GH_API_ACCESS_TOKEN"))

--- a/tests/test_pypi_release.py
+++ b/tests/test_pypi_release.py
@@ -9,6 +9,7 @@ from packaging import version
 
 
 @pytest.mark.pypi
+@pytest.mark.timeout(1800)
 def test_pypi_deploy():
     # Find out the current version of the PyPI package
     def upstream_version(url):


### PR DESCRIPTION
This makes the test suite more robust w.r.t. upstream service inavailabilities.