### PR TITLE
Mark the codecov.io API check as flaky

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,6 @@
 breathe==4.24.1
 cookiecutter==1.7.2
+flaky==3.7.0
 jsonschema==3.2.0
 packaging==20.4
 pybind11==2.6.1

--- a/tests/test_deploy_bake.py
+++ b/tests/test_deploy_bake.py
@@ -139,8 +139,14 @@ def codecov_api_verification(remote_url, token, sha):
     assert commit['totals']['c'] == '100'
 
 
+def wait_five_seconds(*args):
+    time.sleep(5)
+    return True
+
+
 @pytest.mark.integrations
-@pytest.mark.timeout(60)
+@pytest.mark.flaky(max_runs=3, min_passes=1, rerun_filter=wait_five_seconds)
+@pytest.mark.timeout(120)
 def test_codecovio_github_deploy():
     # Authenticate with the Github API to get the upstream commit
     gh = github.Github(os.getenv("GH_API_ACCESS_TOKEN"))


### PR DESCRIPTION
This way it only needs to succeed once in three runs.
This hopefully prevents the occasional failures of that test.

This fixes #37 