### PR TITLE
A few changes to default values

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -6,12 +6,12 @@
     "license": ["MIT", "BSD-2", "GPL-3.0", "LGPL-3.0", "None"],
     "use_submodules": ["Yes", "No"],
     "github_actions_ci": ["Yes", "No"],
-    "gitlab_ci": ["No", "Yes"],
+    "gitlab_ci": ["Yes", "No"],
     "readthedocs": ["Yes", "No"],
     "doxygen": ["Yes", "No"],
     "cxx_minimum_standard": ["11", "14", "17", "20"],
     "python_bindings": ["No", "Yes"],
     "pypi_release": "{{ cookiecutter.python_bindings }}",
     "codecovio": ["Yes", "No"],
-    "sonarcloud": ["Yes", "No"]
+    "sonarcloud": ["No", "Yes"]
 }


### PR DESCRIPTION
`gitlab_ci`: No -> Yes. With the decision to support exactly two CI systems,
it seems safe to enable both by default in order to increase the chances
of users having one set up from the start.

`sonarcloud`: Yes -> No. While I do not very much like this change, it seems
necessary to get a working default configuration. The sonarcloud option just
depends on too many other options.

This fixes #40 