### PR TITLE
WIP: Tox tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,9 +33,9 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
 
-    - name: Install test requirements
+    - name: Install dependencies
       run: |
-        python -m pip install -r requirements-dev.txt
+        python -m pip install tox tox-gh-actions
 
     - name: Install Doxygen (Linux)
       if: runner.os == 'Linux'
@@ -82,9 +82,9 @@ jobs:
       run: |
         git config --system core.longpaths true
 
-    - name: Run regular test suite
+    - name: Test with tox
       run: |
-        python -m pytest -m local
+        tox "-m local"
 
   deploy-test:
     name: Deploying to hosters and run their CI
@@ -99,9 +99,9 @@ jobs:
       with:
         python-version: 3.8
 
-    - name: Install test requirements
+    - name: Install test dependencies
       run: |
-        python -m pip install -r requirements-dev.txt
+        pip install tox tox-gh-actions
 
     - name: Set up git identity
       run: |
@@ -120,7 +120,7 @@ jobs:
 
     - name: Test deploying the baked project to Github + Gitlab.com
       run: |
-        python -m pytest -m deploy
+        tox "-m deploy"
 
     - name: Run tests for upstream integrations
       env:
@@ -130,4 +130,4 @@ jobs:
         GL_API_ACCESS_TOKEN: ${{ secrets.GL_API_ACCESS_TOKEN }}
         RTD_API_ACCESS_TOKEN: ${{ secrets.RTD_API_ACCESS_TOKEN }}
       run: |
-        python -m pytest -m integrations
+        tox "-m -m integrations"

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -24,7 +24,7 @@ jobs:
 
     - name: Install test requirements
       run: |
-        python -m pip install -r requirements-dev.txt
+        python -m pip install tox tox-gh-actions
 
     - name: Set up git identity
       run: |
@@ -39,10 +39,10 @@ jobs:
 
     - name: Test deploying the baked project to Github + Gitlab.com
       run: |
-        python -m pytest -m deploy
+        tox "-m deploy"
 
     - name: Run tests for upstream integrations
       env:
         GH_API_ACCESS_TOKEN: ${{ secrets.GH_API_ACCESS_TOKEN }}
       run: |
-        python -m pytest -m pypi
+        tox "-m pypi"

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,15 @@
+#!/usr/bin/env python
+
+from setuptools import setup
+
+setup(
+    name="cookiecutter-cpp-project",
+    version="0.0.1",
+    description="A Cookiecutter template for CMake-based C++ projects",
+    author="Scientific Software Center Team",
+    author_email="ssc@iwr.uni-heidelberg.de",
+    url="https://github.com/ssciwr/cookiecutter-cpp-project",
+    packages=[],
+    license="MIT",
+    zip_safe=False
+)

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,6 @@
+[tox]
+envlist = py36, py37, py38
+
+[testenv]
+deps = -rrequirements-dev.txt
+commands = pytest {posargs}

--- a/tox.ini
+++ b/tox.ini
@@ -4,3 +4,9 @@ envlist = py36, py37, py38
 [testenv]
 deps = -rrequirements-dev.txt
 commands = pytest {posargs}
+
+[gh-actions]
+python =
+    3.6: py36
+    3.7: py37
+    3.8: py38


### PR DESCRIPTION
Use tox in testing the cookiecutter
    
* makes CI configuration a less moving target
* allows local testing with multiple interpreters
* More portability between CI providers if necessary
