### PR TITLE
Fix PYPI Releases and their testing

### DIFF
--- a/{{cookiecutter.project_slug}}/.github/workflows/pypi.yml
+++ b/{{cookiecutter.project_slug}}/.github/workflows/pypi.yml
@@ -6,7 +6,7 @@ on:
       - published
 
 env:
-  CIBUILDWHEEL_VERSION: 1.7.1
+  CIBUILDWHEEL_VERSION: 1.7.3
 
 jobs:
   build-wheels:
@@ -36,9 +36,15 @@ jobs:
         python-version: '3.7'
         architecture: ${{ "{{ matrix.platform }}" }}
 
-    - name: Install cibuildwheel
+    - name: Install cibuildwheel (Linux + MacOS)
+      if: runner.os != 'Windows'
       run: |
         python -m pip install cibuildwheel==$CIBUILDWHEEL_VERSION
+
+    - name: Install cibuildwheel (Windows)
+      if: runner.os == 'Windows'
+      run: |
+        python -m pip install cibuildwheel==${env:CIBUILDWHEEL_VERSION}
 
     - name: Prepare MSVC
       uses: ilammy/msvc-dev-cmd@v1
@@ -51,7 +57,7 @@ jobs:
         # These variables allow you to customize the process how the wheels
         # for the Python packages are built. For a list of options, see this
         # page: https://cibuildwheel.readthedocs.io/en/stable/options/
-        CIBW_BEFORE_BUILD: python -m pip install cmake
+        CIBW_BEFORE_BUILD: python -m pip install cmake{% if cookiecutter.use_submodules == "No" %} pybind11[global]{% endif %}
         CIBW_SKIP: "*-win32 cp27-* cp35-*"
         CIBW_TEST_COMMAND: pytest {package}/python/tests
         CIBW_TEST_REQUIRES: pytest
@@ -64,7 +70,7 @@ jobs:
         # These variables allow you to customize the process how the wheels
         # for the Python packages are built. For a list of options, see this
         # page: https://cibuildwheel.readthedocs.io/en/stable/options/
-        CIBW_BEFORE_BUILD: python -m pip install cmake
+        CIBW_BEFORE_BUILD: python -m pip install cmake{% if cookiecutter.use_submodules == "No" %} pybind11[global]{% endif %}
         CIBW_SKIP: "*-win_amd64 cp27-* cp35-*"
         CIBW_TEST_COMMAND: pytest {package}/python/tests
         CIBW_TEST_REQUIRES: pytest

--- a/{{cookiecutter.project_slug}}/setup.py
+++ b/{{cookiecutter.project_slug}}/setup.py
@@ -31,7 +31,9 @@ class CMakeBuild(build_ext):
         if not extdir.endswith(os.path.sep):
             extdir += os.path.sep
 
-        cmake_args = ['-DCMAKE_LIBRARY_OUTPUT_DIRECTORY=' + extdir,
+        cmake_args = ['-DBUILD_DOCS=OFF',
+                      '-DBUILD_TESTING=OFF',
+                      '-DCMAKE_LIBRARY_OUTPUT_DIRECTORY=' + extdir,
                       '-DPYTHON_EXECUTABLE=' + sys.executable,
                      ]
 


### PR DESCRIPTION
This has not been touched since we introduced the option
to not use Git submodules. For the no submodule case to
work, Pybind11 needs to be installed into the wheel building
environment. Also fixes a portablity issue with environment
variables in workflow files