### PR TITLE
Implement a configuration option for header-only libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,9 @@ This cookiecutter accepts the following configuration options:
 * `use_submodules`: Whether `git submodule` should be used to add version-pinned external
   dependencies (like e.g. the testing framework `Catch2`). If you do not know what git submodules
   are, you should select `No`.
+* `header_only`: Whether the C++ project is header-only. If `No` is selected, a library will
+  be added to the project. In both cases, a target is exported that dependent projects can
+  link against.
 * `github_actions_ci`: Whether to add a CI workflow for Github Actions
 * `gitlab_ci`: Whether to add a CI workflow for GitLab CI
 * `readthedocs`: Whether to create a Sphinx-documentation that can automatically be deployed to readthedocs.org

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -5,6 +5,7 @@
     "full_name": "Your Name",
     "license": ["MIT", "BSD-2", "GPL-3.0", "LGPL-3.0", "None"],
     "use_submodules": ["Yes", "No"],
+    "header_only": ["Yes", "No"],
     "github_actions_ci": ["Yes", "No"],
     "gitlab_ci": ["Yes", "No"],
     "readthedocs": ["Yes", "No"],

--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -58,6 +58,7 @@ def conditional_remove(condition, path):
 conditional_remove(True, "ext/.keep")
 conditional_remove("{{ cookiecutter.use_submodules }}" == "No", "ext")
 conditional_remove("{{ cookiecutter.license }}" == "None", "LICENSE.md")
+conditional_remove("{{ cookiecutter.header_only }}" == "Yes", "src")
 conditional_remove("{{ cookiecutter.gitlab_ci }}" == "No", ".gitlab-ci.yml")
 conditional_remove("{{ cookiecutter.readthedocs }}" == "No", ".readthedocs.yml")
 conditional_remove("{{ cookiecutter.readthedocs }}" == "No", "doc/conf.py")

--- a/tests/test_bake_project.py
+++ b/tests/test_bake_project.py
@@ -66,6 +66,7 @@ def test_cmake_installation(cookies, header_only):
     downstream_bake = cookies.bake(
         extra_context={
             'project_slug': 'downstream',
+            'header_only': 'No',
             'sonarcloud': 'No',
         }
     )

--- a/tests/test_bake_project.py
+++ b/tests/test_bake_project.py
@@ -45,11 +45,13 @@ def build_cmake(target=None, ctest=False, install=False, **cmake_args):
 
 @pytest.mark.local
 @pytest.mark.parametrize("submodules", ("Yes", "No"))
-def test_ctest_run(cookies, submodules):
+@pytest.mark.parametrize("header_only", ("Yes", "No"))
+def test_ctest_run(cookies, submodules, header_only):
     bake = cookies.bake(
         extra_context={
             'project_slug': 'test_project',
             'use_submodules': submodules,
+            'header_only': header_only,
             'sonarcloud': 'No',
         }
     )
@@ -59,7 +61,8 @@ def test_ctest_run(cookies, submodules):
 
 
 @pytest.mark.local
-def test_cmake_installation(cookies):
+@pytest.mark.parametrize("header_only", ("Yes", "No"))
+def test_cmake_installation(cookies, header_only):
     downstream_bake = cookies.bake(
         extra_context={
             'project_slug': 'downstream',
@@ -69,6 +72,7 @@ def test_cmake_installation(cookies):
     upstream_bake = cookies.bake(
         extra_context={
             'project_slug': 'upstream',
+            'header_only': header_only,
             'sonarcloud': 'No',
         }
     )

--- a/{{cookiecutter.project_slug}}/.github/workflows/ci.yml
+++ b/{{cookiecutter.project_slug}}/.github/workflows/ci.yml
@@ -171,6 +171,6 @@ jobs:
       shell: bash
       working-directory: ${{ "{{runner.workspace}}" }}
       run: |
-        lcov --directory ./build/src --capture --output-file coverage.info
+        lcov --directory ./build{% if cookiecutter.header_only == "No" %}/src{% endif %} --capture --output-file coverage.info
         bash <(curl --connect-timeout 10 --retry 5 -s https://codecov.io/bash) -f coverage.info || echo "Codecov did not collect coverage reports"
 {% endif %}

--- a/{{cookiecutter.project_slug}}/.github/workflows/sonarcloud.yml
+++ b/{{cookiecutter.project_slug}}/.github/workflows/sonarcloud.yml
@@ -68,7 +68,11 @@ jobs:
           ctest
           mkdir gcov
           cd gcov
-          gcov -p ../{% if cookiecutter.header_only == "Yes" %}tests{% else %}src{% endif %}/CMakeFiles/{{ cookiecutter.project_slug }}.dir/*.cpp.gcno > /dev/null
+{%- if cookiecutter.header_only == "Yes" %}
+          gcov -p ../tests/CMakeFiles/tests.dir/*.cpp.gcno > /dev/null
+{%- else %}
+          gcov -p ../tests//CMakeFiles/{{ cookiecutter.project_slug }}.dir/*.cpp.gcno > /dev/null
+{%- endif %}
           cd ../..
           $HOME/.sonar/sonar-scanner-$SONAR_SCANNER_VERSION-linux/bin/sonar-scanner
         env:

--- a/{{cookiecutter.project_slug}}/.github/workflows/sonarcloud.yml
+++ b/{{cookiecutter.project_slug}}/.github/workflows/sonarcloud.yml
@@ -68,7 +68,7 @@ jobs:
           ctest
           mkdir gcov
           cd gcov
-          gcov -p ../src/CMakeFiles/{{ cookiecutter.project_slug }}.dir/*.cpp.gcno > /dev/null
+          gcov -p ../{% if cookiecutter.header_only == "Yes" %}tests{% else %}src{% endif %}/CMakeFiles/{{ cookiecutter.project_slug }}.dir/*.cpp.gcno > /dev/null
           cd ../..
           $HOME/.sonar/sonar-scanner-$SONAR_SCANNER_VERSION-linux/bin/sonar-scanner
         env:

--- a/{{cookiecutter.project_slug}}/.gitlab-ci.yml
+++ b/{{cookiecutter.project_slug}}/.gitlab-ci.yml
@@ -54,6 +54,6 @@ generate-coverage-report:
     - cmake --build .
     - ctest
     - cd ..
-    - lcov --directory ./build/src --capture --output-file coverage.info
+    - lcov --directory ./build{% if cookiecutter.header_only == "No" %}/src{% endif %} --capture --output-file coverage.info
     - bash <(curl --connect-timeout 10 --retry 5 -s https://codecov.io/bash) -f coverage.info || echo "Codecov did not collect coverage reports"
 {%- endif %}

--- a/{{cookiecutter.project_slug}}/CMakeLists.txt
+++ b/{{cookiecutter.project_slug}}/CMakeLists.txt
@@ -32,9 +32,6 @@ target_include_directories({{ cookiecutter.project_slug }} INTERFACE
   $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/include/>
   $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
 )
-
-# Add an alias for use if this project is included as a subproject in another project
-add_library({{ cookiecutter.project_slug }}::{{ cookiecutter.project_slug }} ALIAS {{ cookiecutter.project_slug }})
 {%- endif %}
 
 # compile the application
@@ -70,6 +67,9 @@ if(BUILD_PYTHON)
   add_subdirectory(python)
 endif()
 {%- endif %}
+
+# Add an alias target for use if this project is included as a subproject in another project
+add_library({{ cookiecutter.project_slug }}::{{ cookiecutter.project_slug }} ALIAS {{ cookiecutter.project_slug }})
 
 # Install targets and configuration
 install(

--- a/{{cookiecutter.project_slug}}/CMakeLists.txt
+++ b/{{cookiecutter.project_slug}}/CMakeLists.txt
@@ -22,8 +22,20 @@ set(BUILD_PYTHON ON CACHE BOOL "Enable building of Python bindings")
 set(BUILD_DOCS ON CACHE BOOL "Enable building of documentation")
 {%- endif %}
 
+{%- if cookiecutter.header_only == "No" %}
 # compile the library
 add_subdirectory(src)
+{% else %}
+# Add an interface target for our header-only library
+add_library({{ cookiecutter.project_slug }} INTERFACE)
+target_include_directories({{ cookiecutter.project_slug }} INTERFACE
+  $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/include/>
+  $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
+)
+
+# Add an alias for use if this project is included as a subproject in another project
+add_library({{ cookiecutter.project_slug }}::{{ cookiecutter.project_slug }} ALIAS {{ cookiecutter.project_slug }})
+{%- endif %}
 
 # compile the application
 add_subdirectory(app)

--- a/{{cookiecutter.project_slug}}/FILESTRUCTURE.md
+++ b/{{cookiecutter.project_slug}}/FILESTRUCTURE.md
@@ -4,7 +4,9 @@ generated for you:
 * C++ source files:
   * `include/{{ cookiecutter.project_slug }}/{{ cookiecutter.project_slug }}.hpp` is the main
     C++ header that declares the interface of your library.
+{%- if cookiecutter.header_only == "No" %}
   * `src/{{ cookiecutter.project_slug }}.cpp` is the main file that implements this library.
+{%- endif %}
   * `app/{{ cookiecutter.project_slug }}_app.cpp` is an executable that uses the library.
     This can e.g. be used to provide a command line interface for your project.
   * `tests/{{ cookiecutter.project_slug }}_t.cpp` contains the unit tests for the library.

--- a/{{cookiecutter.project_slug}}/codecov.yml
+++ b/{{cookiecutter.project_slug}}/codecov.yml
@@ -20,5 +20,5 @@ comment:
   require_changes: no
 
 ignore:
-  - "**/tests/*.cpp"
-  - "**/ext/**/*" # external library code
+  - "./tests"
+  - "./ext"

--- a/{{cookiecutter.project_slug}}/codecov.yml
+++ b/{{cookiecutter.project_slug}}/codecov.yml
@@ -20,5 +20,5 @@ comment:
   require_changes: no
 
 ignore:
-  - "./tests"
-  - "./ext"
+  - "**/tests"
+  - "**/Catch2"

--- a/{{cookiecutter.project_slug}}/include/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}.hpp
+++ b/{{cookiecutter.project_slug}}/include/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}.hpp
@@ -13,6 +13,9 @@ namespace {{ cookiecutter.project_slug.replace("-", "") }} {
  * @returns the successor of x
  */
 {%- endif %}
-int add_one(int x);
+int add_one(int x){% if cookiecutter.header_only == "No" %};{%- else %}{
+  return x + 1;
+}
+{%- endif %}
 
 } // namespace {{ cookiecutter.project_slug.replace("-", "") }}

--- a/{{cookiecutter.project_slug}}/include/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}.hpp
+++ b/{{cookiecutter.project_slug}}/include/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}.hpp
@@ -13,7 +13,7 @@ namespace {{ cookiecutter.project_slug.replace("-", "") }} {
  * @returns the successor of x
  */
 {%- endif %}
-int add_one(int x){% if cookiecutter.header_only == "No" %};{%- else %}{
+{% if cookiecutter.header_only == "Yes" %}inline {% endif %}int add_one(int x){% if cookiecutter.header_only == "No" %};{%- else %}{
   return x + 1;
 }
 {%- endif %}

--- a/{{cookiecutter.project_slug}}/sonar-project.properties
+++ b/{{cookiecutter.project_slug}}/sonar-project.properties
@@ -5,7 +5,7 @@ sonar.organization={{ username }}
 sonar.host.url=https://sonarcloud.io
 
 # Path is relative to the sonar-project.properties file. Replace "\" by "/" on Windows.
-sonar.sources=./src
+sonar.sources={% if cookiecutter.header_only == "Yes" %}./include{% else %}./src{% endif %}
 
 # Exclusions
 sonar.coverage.exclusions=tests/*,ext/*

--- a/{{cookiecutter.project_slug}}/sonar-project.properties
+++ b/{{cookiecutter.project_slug}}/sonar-project.properties
@@ -5,7 +5,7 @@ sonar.organization={{ username }}
 sonar.host.url=https://sonarcloud.io
 
 # Path is relative to the sonar-project.properties file. Replace "\" by "/" on Windows.
-sonar.sources={% if cookiecutter.header_only == "Yes" %}./include{% else %}./src{% endif %}
+sonar.sources={% if cookiecutter.header_only == "Yes" %}tests,include{% else %}src{% endif %}
 
 # Exclusions
 sonar.coverage.exclusions=tests/*,ext/*

--- a/{{cookiecutter.project_slug}}/src/CMakeLists.txt
+++ b/{{cookiecutter.project_slug}}/src/CMakeLists.txt
@@ -3,6 +3,3 @@ target_include_directories({{ cookiecutter.project_slug }} PUBLIC
   $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/include/>
   $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
 )
-
-# Add an alias for use if this project is included as a subproject in another project
-add_library({{ cookiecutter.project_slug }}::{{ cookiecutter.project_slug }} ALIAS {{ cookiecutter.project_slug }})


### PR DESCRIPTION
So far, the cookiecutter always assumed the existence of a library. Header-only libraries are quite common, so we add this as an additional configuration option. In the header-only case, an INTERFACE target is added to CMake, so it behaves exactly like the library case from a downstream perspective.

This fixes #53 