### PR TITLE
Specify upstream versions exactly once and bump them

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -14,5 +14,9 @@
     "python_bindings": ["No", "Yes"],
     "pypi_release": "{{ cookiecutter.python_bindings }}",
     "codecovio": ["Yes", "No"],
-    "sonarcloud": ["No", "Yes"]
+    "sonarcloud": ["No", "Yes"],
+    "_catch_version": "2.13.6",
+    "_cibuildwheel_version": "1.11.1",
+    "_pybind_version": "2.6.2",
+    "_sonarscanner_version": "4.6.2.2472"
 }

--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -81,9 +81,9 @@ with GitRepository() as repo:
     repo.add_remote("origin", "{{ cookiecutter.remote_url }}")
 {% endif %}
 {% if cookiecutter.use_submodules == "Yes" %}
-    repo.add_submodule("https://github.com/catchorg/Catch2.git", "ext/Catch2", tag="v2.13.3")
+    repo.add_submodule("https://github.com/catchorg/Catch2.git", "ext/Catch2", tag="v{{ cookiecutter._catch_version }}")
     if "{{ cookiecutter.python_bindings }}" == "Yes":
-        repo.add_submodule("https://github.com/pybind/pybind11.git", "ext/pybind11", tag="v2.6.1")
+        repo.add_submodule("https://github.com/pybind/pybind11.git", "ext/pybind11", tag="v{{ cookiecutter._pybind_version }}")
 {% else %}
     pass
 {% endif %}

--- a/{{cookiecutter.project_slug}}/.github/workflows/ci.yml
+++ b/{{cookiecutter.project_slug}}/.github/workflows/ci.yml
@@ -12,10 +12,12 @@ on:
   # as well as upon manual triggers through the 'Actions' tab of the Github UI
   workflow_dispatch:
 
+{%- if cookiecutter.use_submodules == "No" %}
 env:
-  CATCH2_VERSION: 2.13.3
+  CATCH2_VERSION: {{ cookiecutter._catch_version }}
 {%- if cookiecutter.python_bindings == "Yes" %}
-  PYBIND11_VERSION: 2.6.1
+  PYBIND11_VERSION: {{ cookiecutter._pybind_version }}
+{%- endif %}
 {%- endif %}
 
 jobs:

--- a/{{cookiecutter.project_slug}}/.github/workflows/pypi.yml
+++ b/{{cookiecutter.project_slug}}/.github/workflows/pypi.yml
@@ -6,7 +6,7 @@ on:
       - published
 
 env:
-  CIBUILDWHEEL_VERSION: 1.7.3
+  CIBUILDWHEEL_VERSION: {{ cookiecutter._cibuildwheel_version }}
 
 jobs:
   build-wheels:

--- a/{{cookiecutter.project_slug}}/.github/workflows/sonarcloud.yml
+++ b/{{cookiecutter.project_slug}}/.github/workflows/sonarcloud.yml
@@ -11,9 +11,13 @@ on:
       - reopened
 
 env:
-  CATCH2_VERSION: 2.13.3
-  PYBIND11_VERSION: 2.6.1
-  SONAR_SCANNER_VERSION: 4.4.0.2170
+{%- if cookiecutter.use_submodules == "No" %}
+  CATCH2_VERSION: {{ cookiecutter._catch_version }}
+{%- if cookiecutter.python_bindings == "Yes" %}
+  PYBIND11_VERSION: {{ cookiecutter._pybind_version }}
+{%- endif %}
+{%- endif %}
+  SONAR_SCANNER_VERSION: {{ cookiecutter._sonarscanner_version }}
 
 jobs:
   sonarcloud:

--- a/{{cookiecutter.project_slug}}/.gitlab-ci.yml
+++ b/{{cookiecutter.project_slug}}/.gitlab-ci.yml
@@ -1,9 +1,12 @@
 variables:
 {%- if cookiecutter.use_submodules == "Yes" %}
   GIT_SUBMODULE_STRATEGY: recursive
+{%- else %}
+  CATCH2_VERSION: {{ cookiecutter._catch_version }}
+{%- if cookiecutter.python_bindings == "Yes" %}
+  PYBIND11_VERSION: {{ cookiecutter._pybind_version }}
 {%- endif %}
-  CATCH2_VERSION: 2.13.3
-  PYBIND11_VERSION: 2.6.1
+{%- endif %}
 
 .template: &template
   before_script:


### PR DESCRIPTION
This change adds version numbers of upstream packages that are used throughout the cookiecutter into the `cookiecutter.yaml` file to have them specified exactly once throughout the project. Prefix them with an underscore makes them private - they will not be prompted to the user.