### PR TITLE
bump actions/deps versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ on:
   - cron: "0 5 * * 1"
 
 env:
-  CATCH2_VERSION: 2.13.3
+  CATCH2_VERSION: 2.13.9
 
 jobs:
   test:
@@ -24,15 +24,15 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-18.04, macos-10.15, windows-2019]
+        os: [ubuntu-latest, macos-latest, windows-latest]
         python-version: ["3.8", "3.9", "3.10"]
 
     steps:
     - name: Checking out the cookie cutter repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
 
@@ -91,14 +91,14 @@ jobs:
 
   deploy-test:
     name: Deploying to hosters and run their CI
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
 
     steps:
     - name: Checking out the cookie cutter repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Set up Python 3.8
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: 3.8
 
@@ -112,7 +112,7 @@ jobs:
         git config --global user.name "SSC CI Test User"
 
     - name: Set up SSH Agent to deploy to test repositories
-      uses: webfactory/ssh-agent@v0.4.1
+      uses: webfactory/ssh-agent@v0.5.4
       with:
         ssh-private-key: |
           ${{ secrets.GHA_TEST_PRIVATE_KEY }}

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -11,14 +11,14 @@ on:
 jobs:
   test-pypi-release:
     name: Testing PyPI release
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
 
     steps:
     - name: Checking out the cookie cutter repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+    - name: Set up Python
+      uses: actions/setup-python@v4
       with:
         python-version: 3.8
 

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -15,8 +15,8 @@
     "pypi_release": "{{ cookiecutter.python_bindings }}",
     "codecovio": ["Yes", "No"],
     "sonarcloud": ["No", "Yes"],
-    "_catch_version": "2.13.8",
-    "_cibuildwheel_version": "2.3.1",
-    "_pybind_version": "2.9.1",
-    "_sonarscanner_version": "4.6.2.2472"
+    "_catch_version": "2.13.9",
+    "_cibuildwheel_version": "2.8.0",
+    "_pybind_version": "2.9.2",
+    "_sonarscanner_version": "4.7.0.2747"
 }

--- a/{{cookiecutter.project_slug}}/.github/workflows/ci.yml
+++ b/{{cookiecutter.project_slug}}/.github/workflows/ci.yml
@@ -26,10 +26,10 @@ jobs:
     runs-on: ${{ "{{matrix.os}}" }}
     strategy:
       matrix:
-        os: [ubuntu-18.04, macos-10.15, windows-2019]
+        os: [ubuntu-latest, macos-latest, windows-latest]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 {% if cookiecutter.use_submodules == "Yes" %}
       with:
         submodules: 'recursive'
@@ -101,17 +101,17 @@ jobs:
     runs-on: ${{ "{{matrix.os}}" }}
     strategy:
       matrix:
-        os: [ubuntu-18.04, macos-10.15, windows-2019]
+        os: [ubuntu-latest, macos-latest, windows-latest]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 {% if cookiecutter.use_submodules == "Yes" %}
       with:
         submodules: 'recursive'
 {%- endif %}
 
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: 3.8
 
@@ -126,10 +126,10 @@ jobs:
 {% if cookiecutter.codecovio == "Yes" %}
   coverage-test:
     name: Coverage Testing
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 {% if cookiecutter.use_submodules == "Yes" %}
       with:
         submodules: 'recursive'

--- a/{{cookiecutter.project_slug}}/.github/workflows/pypi.yml
+++ b/{{cookiecutter.project_slug}}/.github/workflows/pypi.yml
@@ -13,17 +13,17 @@ jobs:
 
     strategy:
       matrix:
-        os: [ubuntu-20.04, windows-2019, macos-10.15]
+        os: [ubuntu-latest, windows-latest, macos-latest]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         submodules: 'recursive'
 
     - name: Build wheels
       uses: pypa/cibuildwheel@v{{ cookiecutter._cibuildwheel_version }}
 
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v3
       with:
         path: ./wheelhouse/*.whl
 
@@ -32,7 +32,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name == 'release' && github.event.action == 'published'
     steps:
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: artifact
           path: dist
@@ -48,7 +48,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name == 'release' && github.event.action == 'published'
     steps:
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: artifact
           path: dist

--- a/{{cookiecutter.project_slug}}/.github/workflows/sonarcloud.yml
+++ b/{{cookiecutter.project_slug}}/.github/workflows/sonarcloud.yml
@@ -24,7 +24,7 @@ jobs:
     name: SonarCloud
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
           submodules: 'recursive'
@@ -57,7 +57,7 @@ jobs:
           unzip -o $HOME/.sonar/build-wrapper-linux-x86.zip -d $HOME/.sonar/
 
       - name: Cache SonarCloud analysis results across runs
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: $HOME/.sonarcache
           key: sonar-${{ "{{ github.job }}" }}-{{ "${{ runner.os }}" }}-${{ "{{ github.sha }}" }}


### PR DESCRIPTION
- use `-latest` for all os versions in workflows
- actions, catch, pybind, cibuildwheel, sonar -> latest versions
