### PR TITLE
Switch to Catch2 v3

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -21,6 +21,6 @@
         "local_extensions.CurrentDateExtension"
     ],
     "__python_module": "{{ cookiecutter|modname }}",
-    "_catch_version": "2.13.10",
+    "_catch_version": "3.10.0",
     "_cibuildwheel_version": "2.22.0"
 }

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -11,7 +11,7 @@
     "gitlab_ci": ["Yes", "No"],
     "readthedocs": ["Yes", "No"],
     "doxygen": ["Yes", "No"],
-    "cxx_minimum_standard": ["11", "14", "17", "20"],
+    "cxx_minimum_standard": ["11", "14", "17", "20", "23"],
     "python_bindings": ["No", "Yes"],
     "pypi_release": "{{ cookiecutter.python_bindings }}",
     "codecovio": "{{ cookiecutter.github_actions_ci }}",

--- a/{{cookiecutter.project_slug}}/CMakeLists.txt
+++ b/{{cookiecutter.project_slug}}/CMakeLists.txt
@@ -58,10 +58,7 @@ include(CTest)
 if(BUILD_TESTING)
   {%- if cookiecutter.use_submodules == "Yes" %}
   add_subdirectory(ext/Catch2)
-  include(./ext/Catch2/contrib/Catch.cmake)
-  {%- else %}
-  find_package(Catch2 REQUIRED)
-  include(Catch)
+  include(./ext/Catch2/extras/Catch.cmake)
   {%- endif %}
   add_subdirectory(tests)
 endif()

--- a/{{cookiecutter.project_slug}}/FILESTRUCTURE.md
+++ b/{{cookiecutter.project_slug}}/FILESTRUCTURE.md
@@ -12,9 +12,6 @@ generated for you:
   * `tests/{{ cookiecutter.project_slug }}_t.cpp` contains the unit tests for the library.
     The unit tests are written using Catch2. For further reading on what can be achieved
     with Catch2, we recommend [their tutorial](https://github.com/catchorg/Catch2/blob/devel/docs/tutorial.md).
-  * `tests/tests.cpp` is the Catch2 testing driver. You do not need to change
-    this. Placing this in a separate compilation unit than the unit test
-    implementation decreases the compilation time of the test suite.
 {%- if cookiecutter.python_bindings == "Yes" %}
   * The `python/{{ cookiecutter.project_slug.replace("-", "") }}` directory contains a Python
     package for the project. It contains a compiled Python module `_{{ cookiecutter.project_slug.replace("-", "") }}`

--- a/{{cookiecutter.project_slug}}/tests/CMakeLists.txt
+++ b/{{cookiecutter.project_slug}}/tests/CMakeLists.txt
@@ -1,5 +1,39 @@
-add_executable(tests tests.cpp {{ cookiecutter.project_slug }}_t.cpp)
-target_link_libraries(tests PUBLIC {{ cookiecutter.project_slug }} Catch2::Catch2)
+{%- if cookiecutter.use_submodules == "No" %}
+# ------------------------------------------------------------------------------
+# Enable CMake's FetchContent module, which allows downloading dependencies like
+# Catch2 automatically at configure time.
+# ------------------------------------------------------------------------------
+include(FetchContent)
+
+# ------------------------------------------------------------------------------
+# Declare a dependency on Catch2 via FetchContent. This will clone the Catch2
+# GitHub repository during configuration.
+# ------------------------------------------------------------------------------
+FetchContent_Declare(
+  Catch2
+  GIT_REPOSITORY https://github.com/catchorg/Catch2.git
+  GIT_TAG v{{ cookiecutter._catch_version }})
+
+# ------------------------------------------------------------------------------
+# Make Catch2 available in this project. This defines the CMake targets like
+# Catch2::Catch2 and Catch2::Catch2WithMain.
+# ------------------------------------------------------------------------------
+FetchContent_MakeAvailable(Catch2)
+
+# ------------------------------------------------------------------------------
+# Make Catch2 available in this project. This defines the CMake targets like
+# Catch2::Catch2 and Catch2::Catch2WithMain.
+# ------------------------------------------------------------------------------
+include(Catch)
+{%- endif %}
+
+# ------------------------------------------------------------------------------
+# Create a single test binary that compiles all test files.
+# ------------------------------------------------------------------------------
+add_executable(tests {{ cookiecutter.project_slug }}_t.cpp)
+
+# Link the test binary
+target_link_libraries(tests PUBLIC {{ cookiecutter.project_slug }} Catch2::Catch2WithMain)
 
 # allow user to run tests with `make test` or `ctest`
 catch_discover_tests(tests)

--- a/{{cookiecutter.project_slug}}/tests/{{cookiecutter.project_slug}}_t.cpp
+++ b/{{cookiecutter.project_slug}}/tests/{{cookiecutter.project_slug}}_t.cpp
@@ -1,5 +1,5 @@
 #include "{{ cookiecutter.project_slug }}/{{ cookiecutter.project_slug }}.hpp"
-#include "catch2/catch.hpp"
+#include <catch2/catch_test_macros.hpp>
 
 using namespace {{ cookiecutter.project_slug.replace("-", "") }};
 


### PR DESCRIPTION
Replaces Catch2 v2 submodule with v3.10, either as submodule or via ```FetchContent```.
Solves Issue #129